### PR TITLE
fix: 修复跨主机部署时发送图片导致的 ENOENT 错误

### DIFF
--- a/nonebot_plugin_gold_price/gold_price.py
+++ b/nonebot_plugin_gold_price/gold_price.py
@@ -10,6 +10,7 @@ from nonebot.adapters import Message
 from nonebot.params import CommandArg
 from nonebot.plugin import PluginMetadata
 import aiohttp
+import base64
 
 require("nonebot_plugin_apscheduler")
 require("nonebot_plugin_localstore")  # 声明依赖
@@ -305,8 +306,10 @@ async def send_price_report(conn, sh_data, lf_data, bot: Bot, days, group_id=Non
             group_id=group_id, message=MessageSegment.text(final_msg)
         )
         if chart_data:
+            with open(chart_path, "rb") as f:
+                img_base64 = base64.b64encode(f.read()).decode()
             await bot.send_group_msg(
-                group_id=group_id, message=MessageSegment.image(f"file:///{chart_path}")
+                group_id=group_id, message=MessageSegment.image(f"base64://{img_base64}")
             )
 
     if isinstance(sh_data, dict):
@@ -494,9 +497,11 @@ async def daily_report():
 
                 # 发送图表
                 if generate_chart_data:
+                    with open(chart_path, "rb") as f:
+                        img_base64 = base64.b64encode(f.read()).decode()
                     await bot.send_group_msg(
                         group_id=group_id,
-                        message=MessageSegment.image(f"file:///{chart_path}"),
+                        message=MessageSegment.image(f"base64://{img_base64}"),
                     )
 
                 # 发送预警


### PR DESCRIPTION
## 问题概述
修复在 NoneBot 和 OneBot (NapCat) 部署在不同主机时，发送图片失败的问题（报错 ENOENT）。

## 详细说明
原来插件使用：
```python
MessageSegment.image(f"file:///{chart_path}")
```
在跨主机部署时，NapCat 无法访问本地路径，导致发送失败。
解决方案：改为使用 base64 编码发送图片：

```python
import base64

with open(chart_path, "rb") as f:
    img_base64 = base64.b64encode(f.read()).decode()

await bot.send_group_msg(
    group_id=group_id,
    message=MessageSegment.image(f"base64://{img_base64}")
)
```

## 修改效果
跨主机部署时图片可以正常发送；
单机部署仍然兼容；
消除了 ENOENT 错误。